### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ const {createNode} = require('@beaker/dat-node')
 
 // instantiate a new dat node
 const dat = createNode({
-  storage: './dat'
+  path: './dat'
 })
 
 // get, create, or fork archives


### PR DESCRIPTION
The `storage` module requires a `path` option, not a `storage` option.